### PR TITLE
v5 - Rehauled flow, added getopts support, added OSX md5 support, rem…

### DIFF
--- a/.kode/kodeconfig
+++ b/.kode/kodeconfig
@@ -1,3 +1,0 @@
-AUTHOR="Set name with -a"
-TXT_EDITOR=${VISUAL:-"${EDITOR:-vi}"}
-INSERT_CODE=true

--- a/.kode/kodeconfig.temp
+++ b/.kode/kodeconfig.temp
@@ -1,0 +1,3 @@
+KODE_AUTHOR="<unset>"
+EDITOR=${VISUAL:-"${EDITOR:-vi}"}
+INSERT_CODE=true

--- a/.version
+++ b/.version
@@ -1,0 +1,34 @@
+kode v5
+
+A bash script to
+ -> Add shebang
+ -> Add info header
+ -> Add code template (can be toggled)
+ -> Make code executable
+ -> Update Last modified column in info header
+
+Authors : https://github.com/laraib07
+          https://github.com/GetOutOfMyBakery
+
+Supported languages :
+  bash, c, c++, c#, css, java, javascript, perl,
+  php, python, ruby, rust, swift, sh, typescript.
+
+v5:
+  features:
+  - Added support for OSX default (or other OS's with md5 as default)
+  - Removed need for ~/.kode directory (manually delete this if a previous version has run)
+  - Locally run without install or sudo:
+        alias kode="\"$PWD/kode\""
+      or add:
+        alias kode="<path_to_kode>/kode"
+      to your ~/.bashrc file, substiting in the full path
+
+  tech debt:
+  - Rehaul of the overall flow, making adding new templates easier
+  - Using getopts for arg parsing
+  - Added debugging for quickly iterating through example files
+  - Added config dump (flag '-d') for debugging
+  - Moved version info to a seperate file
+  - Reduced duplication and setting things in mulitple places
+  - Added an alert for non-scripting language files that don't have an available template

--- a/.version
+++ b/.version
@@ -22,13 +22,13 @@ v5:
         alias kode="\"$PWD/kode\""
       or add:
         alias kode="<path_to_kode>/kode"
-      to your ~/.bashrc file, substiting in the full path
+      to your ~/.bashrc file, substituting in the full path
 
   tech debt:
   - Rehaul of the overall flow, making adding new templates easier
   - Using getopts for arg parsing
   - Added debugging for quickly iterating through example files
   - Added config dump (flag '-d') for debugging
-  - Moved version info to a seperate file
-  - Reduced duplication and setting things in mulitple places
+  - Moved version info to a separate file
+  - Reduced duplication and setting things in multiple places
   - Added an alert for non-scripting language files that don't have an available template

--- a/kode
+++ b/kode
@@ -1,248 +1,231 @@
 #!/usr/bin/env bash
 
-#**************************************************#
-#                                                  #
-#   kode v4.5                                      #
-#   A bash script to                               #
-#   -> Add shebang                                 #
-#   -> Add info header                             #
-#   -> Add code template (can be toggled)          #
-#   -> Make code executable                        #
-#   -> Update Last modified column of info header  #
-#                                                  #
-#   Author : https://github.com/laraib07           #
-#                                                  #
-#   Supported languages :                          #
-#   bash, c, c++, c#, css, java,                   #
-#   javascript, perl, php, python,                 #
-#   ruby, rust, swift, typescript.                 #
-#                                                  #
-#**************************************************#
+program_name=$(basename "$0")
 
+# Adds support so that the 'kode' checkout dir is where the config is stored and read from
+SCRIPT_ROOT_DIR="$(dirname "$(readlink -f "$0")")"
+cd "$SCRIPT_ROOT_DIR" || exit 1
 
 #colors and variables
 R='\033[1;31m'
 G='\033[1;32m'
 W='\033[1;37m'
 OFF='\033[0m'
-DATE=$(date '+%a %d %b %y  %R:%S')
+DATE="$(date '+%a %d %b %y  %R:%S')"
 FORMAT="%-16s %-30s %s\n"
-CODE_TEMPLATE="$HOME/.kode"
-CONFIG_FILE="$HOME/.kode/kodeconfig"
+CODE_TEMPLATE="$SCRIPT_ROOT_DIR/.kode"
+CONFIG_FILE="$CODE_TEMPLATE/kodeconfig"
+DEFAULT_CONFIG_FILE="$CONFIG_FILE.temp"
+
+DEBUG=false # When enabled, prints the file, rather than opening in editor
 
 
-# checking config file [ FAILSAFE ]
-if ! [[ -f "$CONFIG_FILE" ]]
-then
-    mkdir "$HOME"/.kode &> /dev/null
-    touch "$CONFIG_FILE"
-    printf "AUTHOR=\"Set name with -a\"\n" > "$CONFIG_FILE"
-    printf "TXT_EDITOR=\${VISUAL:-\"\${EDITOR:-vi}\"}\n" >> "$CONFIG_FILE"
-    printf "INSERT_CODE=true\n" >> "$CONFIG_FILE"
-fi
+#### FUNCTIONS
 
-# sourcing config file
-source "$CONFIG_FILE"
+function help_function() {
+    printf "Usage : ${W}$program_name${OFF}  [-dhvtx] [-a name] [file...]
 
-
-header_template()
-{
-    printf "************************************************#\n"
-    printf "#%-49s#\n"
-    printf "$FORMAT" "#  Project title :"  "$1" '#'
-    printf "$FORMAT" "#  Author        :"  "${AUTHOR}" '#'
-    printf "$FORMAT" "#  Date          :"  "${DATE}" '#'
-    printf "$FORMAT" "#  Last modified :"  "${DATE}" '#'
-    printf "$FORMAT" "#  Notes         :"  "" '#'
-    printf "$FORMAT" "#  Description   :"  "" '#'
-    printf "#%-49s#\n"
-    printf "#************************************************"
-
+    -a\t Set Author Name (e.g. '$program_name -a \"Author Name\"')
+    -d\t Display config information (for debugging)
+    -h\t Display this help message
+    -t\t Toggle code insertion mode
+    -v\t Display version info\n"
+    exit
 }
 
 
-insert_code_template()
-{
-    # inserting code template
-    case "$1" in
-        *.c )
-            cat "$CODE_TEMPLATE"/c.temp >> "$1" ;;
+function source_config() {
+    # Generates a default config from the temp file, if not present, and loads kodeconfig
+    if [[ ! -f "$CONFIG_FILE" ]]; then
+        cp "$DEFAULT_CONFIG_FILE" "$CONFIG_FILE"
+    fi
 
-        *.cpp )
-            cat "$CODE_TEMPLATE"/cpp.temp >> "$1" ;;
-
-        *.cs )
-            cat "$CODE_TEMPLATE"/cs.temp >> "$1" ;;
-
-        *.java )
-            cat "$CODE_TEMPLATE"/java.temp >> "$1" ;;
-
-        *.rs )
-            cat "$CODE_TEMPLATE"/rs.temp >> "$1" ;;
-    esac
+    # shellcheck source=./.kode/kodeconfig
+    source "$CONFIG_FILE"
 }
 
+function display_config() {
+    local display_config_format="%-25s %s\n"
+    source_config   # ensure the config exists
 
-insert_shebang_header()
-{
-    # checking if shebang required
-    if [[ "$1" =~ \.(pl|py|rb|sh)$ ]]
-    then
-        # checking environment
-        case "$1" in
-            *.pl ) environment=perl ;;
-            *.py ) environment=python3 ;;
-            *.rb ) environment=ruby ;;
-            *.sh ) environment=bash ;;
-        esac
+    printf "$display_config_format" "env:" "$(which env)"
+    printf "$display_config_format" "CODE_TEMPLATE:" "$CODE_TEMPLATE"
+    printf "$display_config_format" "CONFIG_FILE:" "$CONFIG_FILE"
+    printf "$display_config_format" "DEFAULT_CONFIG_FILE:" "$DEFAULT_CONFIG_FILE"
+    printf "\n"
 
-        # appending shebang
-        printf "#!$(which env) "$environment"\n\n" >> "$1"
-        # appending header template
-        printf "#*$(header_template "$1")*#\n\n" >> "$1"
+    printf "\n$CONFIG_FILE:\n\n"
+    cat "$CONFIG_FILE"
+    exit 0
+}
 
-    elif [[ "$1" =~ \.(c|cpp|cs|css|java|js|php|rs|swift|ts)$ ]]
-    then
-        # shebang not requied
-        # appending header template only
-        printf "/*$(header_template "$1")*/\n\n" >> "$1"
+function set_author() {
+    source_config   # ensure the config exists
+    sed -i "0,/^KODE_AUTHOR.*/{s//KODE_AUTHOR=\"$1\"/}" "$CONFIG_FILE"
+    printf "Author name set to \"$1\".\n"
+    exit 0
+}
 
-        if [[ "$INSERT_CODE" == "true" ]]
-        then
-            insert_code_template "$1"
+function header_template() {
+    # Pass open and closing comments character: $1
+    printf "$1*************************************************#\n"
+
+    printf "$FORMAT" "#" "" "  #"
+    printf "$FORMAT" "#  Project title :" "$filename" "#"
+    printf "$FORMAT" "#  Author        :" "$KODE_AUTHOR" "#"
+    printf "$FORMAT" "#  Date          :" "$DATE" "#"
+    printf "$FORMAT" "#  Last modified :" "$DATE" "#"
+    printf "$FORMAT" "#  Notes         :" "" "#"
+    printf "$FORMAT" "#  Description   :" "" "#"
+
+    printf "$FORMAT" "#" "" "  #"
+    printf "#*************************************************$1\n\n"
+}
+
+function insert_code_template() {
+    # Generates code template by matching pattern: `.extension` to `./.kode/extension.temp`
+    extension="${filename##*.}" # Strip everything before the last '.' in the filename
+
+    if [[ "$extension" ]]; then
+        template_file="$CODE_TEMPLATE/$extension.temp"
+        if [[ -f "$template_file" ]]; then
+            cat "$template_file" >> "$filename"
+        else
+            printf "No template exists for extension: $extension\n"
         fi
     fi
 }
 
-
-update_last_modified()
-{
-    replace_with=$(printf "$FORMAT"  "#  Last modified :" "${DATE}" '#')
-
-    # update first occurrence of last modified
-    sed -i "0,/^#  Last modified.*/{s//${replace_with}/}" "$1"
-}
-
-
-toggle_code_insertion()
-{
-    # if INSERT_CODE is true then assign it false
-    if [[ "$INSERT_CODE" == "true" ]]
-    then
-        sed -i "s/true/false/g" "$CONFIG_FILE"
-        printf  "code insertion ${R}disabled.\n"
-
-    elif [[ "$INSERT_CODE" == "false" ]]
-    then
-        sed -i "s/false/true/g" "$CONFIG_FILE"
-        printf  "code insertion ${G}enabled.\n"
-    fi
-}
-
-
-file_exists()
-{
-    md5sum1="$(printf "%.33s" $(md5sum "$1"))"
-
-    "$TXT_EDITOR" "$1"
-
-    md5sum2="$(printf "%.33s" $(md5sum "$1"))"
-
-    if [[ "$new" == "true"  && "$md5sum1" == "$md5sum2" ]]
-    then
-        rm -f "$1"
-
-    elif [[ "$md5sum1" != "$md5sum2" ]]
-    then
-        update_last_modified "$1"
-    fi
-}
-
-
-is_new_file()
-{
-    touch "$1"
-    chmod u+x "$1"             # making file executable
-
-    insert_shebang_header "$1" # inserting shebang and header
-
-    new=true
-    file_exists "$1"
-}
-
-
-help()
-{
-    printf  "${OFF}Usage : ${W}kode${OFF} [-hvt] [-a name] [file...]\n"
-    printf  " -h    --help                     Print help\n"
-    printf  " -v    --version                  Print version\n"
-    printf  " -a    --set-author               Set author name\n"
-    printf  " -t    --toggle-code-insertion    toggle code insertion\n"
-}
-
-
-version()
-{
-    printf "${OFF}kode v4.5\n"
-    printf "A bash script to\n"
-    printf " -> Add shebang\n"
-    printf " -> Add info header\n"
-    printf " -> Add code template (can be toggled)\n"
-    printf " -> Make code executable\n"
-    printf " -> Update Last modified column in info header\n\n"
-    printf "Author : https://github.com/laraib07\n\n"
-    printf "Supported languages : \n"
-    printf "bash, c, c++, c#, css, java, javascript, perl,\n"
-    printf "php, python, ruby, rust, swift, typescript.\n"
-}
-
-
-# if no argument provided
-if [[ -z "$1" ]]
-then
-    printf "No argument provided.\n"
-    printf "Provide atleast one argument.\n"
-fi
-
-
-# Driver Code
-while [[ -n "$1" ]]
-do
-    case "$1" in
-        "-h" | "--help" )
-            help ;;
-
-        "-v" | "--version" )
-            version ;;
-
-        "-a" | "--set-author" )
-            if [[ -n "$2" ]]
-            then
-                sed -i "0,/^AUTHOR.*/{s//AUTHOR=$2/}" "$CONFIG_FILE"
-                printf "Author name set to $2.\n" 
-            else
-                printf "Usage : kode -a name\n"
-            fi
-            shift
-            ;;
-
-        "-t" | "--toggle-code-insertion" )
-            toggle_code_insertion ;;
-
-        [!-]* )
-            if [[ -f "$1" ]]; then
-                file_exists "$1"
-            else
-                is_new_file  "$1"
-            fi
-            ;;
-
-        * )
-            printf " $1 is invalid option\n" 
-            printf "Try \"-h\" or \"--help\" for help!\n"
-            ;;
+function check_if_scripting_language() {
+    case "$filename" in
+        *.pl ) scripting_language="perl";;
+        *.py ) scripting_language="python3";;
+        *.rb ) scripting_language="ruby";;
+        *.sh ) scripting_language="bash";;
     esac
-    shift
+}
+
+function generate_header() {
+    COMMENT_CHARACTER="/"   # Default to '/'
+
+    check_if_scripting_language
+    if [[ "$scripting_language" ]]; then
+        printf "#!$(which env) $scripting_language\n\n" >> "$filename"    # Add env header
+        COMMENT_CHARACTER="#"   # Set for scripting languages
+    fi
+
+    header_template "$COMMENT_CHARACTER" >> "$filename"
+    if [[ "$INSERT_CODE" == true && -z "$scripting_language" ]]; then insert_code_template; fi
+}
+
+function update_last_modified() {
+    replace_with=$(printf "$FORMAT" "#  Last modified :" "${DATE}" '#')
+    sed -i "0,/^#  Last modified.*/{s//${replace_with}/}" "$1"  # update first occurrence of "Last modified"
+}
+
+function toggle_config_state() {
+    # Toggles a boolean kodeconfig var
+    if [[ -z "$1" ]];
+        then printf "Expected kodeconfig variable"; exit 1;
+    else
+        kodeconfig_var="$1"
+    fi
+
+    current_toggle_state="$(grep "$kodeconfig_var" "$CONFIG_FILE" | cut -d '=' -f 2)"
+
+    if [[ "$current_toggle_state" = true ]]; then
+        sed -i "s/$kodeconfig_var=true/$kodeconfig_var=false/" "$CONFIG_FILE"
+        printf "$kodeconfig_var ${R}disabled.${OFF}\n"
+    elif [[ "$current_toggle_state" = false  ]]; then
+        sed -i "s/$kodeconfig_var=false/$kodeconfig_var=true/" "$CONFIG_FILE"
+        printf  "$kodeconfig_var ${G}enabled.${OFF}\n"
+    elif [[ "$current_toggle_state" ]]; then
+        printf "Key \"$kodeconfig_var\" has value \"$current_toggle_state\" in \"$CONFIG_FILE\". Unable to toggle.\n"
+    else
+        printf "Key \"$kodeconfig_var\" not found in \"$CONFIG_FILE\"\n"
+        exit 1
+    fi
+}
+
+function toggle_code_insertion() {
+    source_config   # ensure the config exists
+    toggle_config_state "INSERT_CODE"
+    exit 0
+}
+
+function determine_md5_program() {
+    # Added support for OSX default (or other OS's with md5 as default)
+    if [[ $(type -p md5sum ) ]]; then
+        printf "md5sum"
+    elif [[ $(type -p md5 ) ]]; then
+        printf "md5"
+    else
+        printf "Please install 'md5sum' or 'md5' to use this program\n"
+        exit 1
+    fi
+}
+
+function generate_md5_checksum() {
+    printf "$($md5_command "$1" | cut -d " " -f 1)"
+}
+
+function generate_new_file() {
+    generate_header "$filename"
+    chmod u+x "$filename"
+    new=true
+}
+
+function kodify() {
+    # Handles generating a new file with the appropriate headers
+    # and template (where supported)
+
+    new=false
+    if [[ ! -f "$filename" ]]; then generate_new_file; fi
+
+    md5_before="$(generate_md5_checksum "$filename")"
+    if [[ "$DEBUG" == true ]]; then
+        cat "$filename"
+    else
+        "$EDITOR" "$filename"
+    fi
+    md5_after="$(generate_md5_checksum "$filename")"
+}
+
+function post_processing() {
+    if [[ "$new" = true  && "$md5_before" == "$md5_after" ]]; then
+        # Delete the file if it's only the default template
+        rm -f "$filename"
+    elif [[ "$md5_before" != "$md5_after" ]]; then
+        update_last_modified "$filename"
+    fi
+}
+
+function version() {
+    cat "$SCRIPT_ROOT_DIR/.version"
+    exit 0
+}
+
+
+#### Parse Args and Setup
+md5_command=$(determine_md5_program)
+
+while getopts ":dhvta:" flag; do
+    case "${flag}" in
+        a) set_author "${OPTARG}";;
+        d) display_config;;
+        h) help_function;;
+        t) toggle_code_insertion;;
+        v) version;;
+        :) printf "No input"; help_function;;
+        *) printf "$program_name: Invalid option -- '${OPTARG}'\n"; help_function;;
+    esac
 done
+
+if [[ -z "$1" ]]; then printf "$program_name: No file provided\n"; help_function; else filename="$1"; fi
+source_config
+
+#### RUN
+kodify
+post_processing
 
 exit 0


### PR DESCRIPTION
…oved need for ~/.kode dir

v5:
  features:
  - Added support for OSX default (or other OS's with `md5` as default)
  - Removed need for `~/.kode/` directory (manually delete this if a previous version has run)
  - Locally run without install or sudo:
        `alias kode="\"$PWD/kode\""`
      or add:
        `alias kode="<path_to_kode>/kode"`
      to your `~/.bashrc` file, substituting in the full path

  tech debt:
  - Rehaul of the overall flow, making adding new templates easier (just add "<extension>.temp" files to `.kode/`
  - Using `getopts` for arg parsing
  - Added debugging for quickly iterating through example files
  - Added config dump (flag '-d') for debugging
  - Moved version info to a separate file
  - Reduced duplication and setting things in multiple places
  - Added an alert for non-scripting language files that don't have an available template
